### PR TITLE
Add support for default admin credentials

### DIFF
--- a/cjdnsadmin/cjdnsadmin.py
+++ b/cjdnsadmin/cjdnsadmin.py
@@ -12,8 +12,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """cjdnsadmin is a library for communicating with the cjdns admin interface"""
 
+from __future__ import print_function
 
 import os
+import sys
 import socket
 import hashlib
 import json
@@ -268,16 +270,12 @@ def connectWithAdminInfo(path=None):
         with open(path, 'r') as adminInfo:
             data = json.load(adminInfo)
     except IOError:
-        print('Please create a file named .cjdnsadmin in your ')
-        print('home directory with')
-        print('ip, port, and password of your cjdns engine in json.')
-        print('for example:')
-        print('{')
-        print('    "addr": "127.0.0.1",')
-        print('    "port": 11234,')
-        print('    "password": "You tell me! (Search in ~/cjdroute.conf)"')
-        print('}')
-        raise
+        print('~/.cjdnsadmin not found; using default credentials', file=sys.stderr)
+        data = {
+            'password': 'NONE',
+            'addr': '127.0.0.1',
+            'port': 11234,
+        }
 
     return connect(data['addr'], data['port'], data['password'])
 

--- a/pep8.ini
+++ b/pep8.ini
@@ -1,0 +1,2 @@
+[pep8]
+max-line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@ envlist = py26,py27,py32,py33,py34
 [testenv]
 deps = pep8
 commands=
-  pep8 cjdnsadmin/__init__.py
-  pep8 cjdnsadmin/cjdnsadmin.py
-  pep8 cjdnsadmin/bencode.py
-  pep8 util/peerStats
-  pep8 util/cexec
+  pep8 --config=pep8.ini cjdnsadmin/__init__.py
+  pep8 --config=pep8.ini cjdnsadmin/cjdnsadmin.py
+  pep8 --config=pep8.ini cjdnsadmin/bencode.py
+  pep8 --config=pep8.ini util/peerStats
+  pep8 --config=pep8.ini util/cexec
   {envpython} setup.py install
   {envpython} tests/ping.py


### PR DESCRIPTION
Later I think it would be good to use the python `logger` module instead for better integration with the applications' logging, since it is a widely used logging solution in python projects.
