### PR TITLE
Codestyle

### DIFF
--- a/cjdns/__init__.py
+++ b/cjdns/__init__.py
@@ -10,8 +10,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""cjdns
-Allows communication with an instance of cjdns via the admin/RPC port.
+"""Allows communication with an instance of cjdns via the admin/RPC port.
 
 Usage:
 

--- a/cjdns/base32.py
+++ b/cjdns/base32.py
@@ -12,8 +12,8 @@
 
 
 # see util/Base32.h
-def decode(input):
-    output = bytearray(len(input))
+def decode(encoded):
+    output = bytearray(len(encoded))
     numForAscii = [
         99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99,
         99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99,
@@ -30,14 +30,14 @@ def decode(input):
     nextByte = 0
     bits = 0
 
-    while (inputIndex < len(input)):
-        o = ord(input[inputIndex])
+    while (inputIndex < len(encoded)):
+        o = ord(encoded[inputIndex])
         if (o & 0x80):
             raise ValueError
         b = numForAscii[o]
         inputIndex += 1
         if (b > 31):
-            raise ValueError("bad character " + input[inputIndex])
+            raise ValueError("bad character " + encoded[inputIndex])
 
         nextByte |= (b << bits)
         bits += 5

--- a/cjdns/cjdns.py
+++ b/cjdns/cjdns.py
@@ -27,7 +27,6 @@ except ImportError:
     import Queue as queue
 import random
 import string
-from hashlib import sha512
 from .bencode import bencode, bdecode
 
 BUFFER_SIZE = 69632


### PR DESCRIPTION
I cleaned up some minor codestyle issues:
- `cjdns/__init__.py`: (from flake8):  1 blank line required between summary line and description. We just had the word "cjdns" on the summary line, and a description on the next line.
- `cjdns/base32.py`: function accepted an argument named `input`, which is [the name of a python builtin](https://docs.python.org/3/library/functions.html#input) and shouldn't be re-defined.
- `cjdns/cjdns.py`: removed unused import `sha512`
